### PR TITLE
Filter credentials

### DIFF
--- a/examples/web-demo/package.json
+++ b/examples/web-demo/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
-    "build": "tsc && vite build",
+    "build": "cd ../.. && npm run build && cd examples/web-demo && tsc && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mina-attestations",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mina-attestations",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/web-demo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-attestations",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "workspaces": [
     "examples/web-demo",
     "examples/web-demo/api-server"

--- a/src/credential-recursive.ts
+++ b/src/credential-recursive.ts
@@ -95,6 +95,11 @@ function Recursive<
         credIdent,
       ]);
     },
+
+    matchesSpec(witness) {
+      // TODO should check proof type
+      return witness.type === 'recursive';
+    },
   };
 }
 
@@ -151,6 +156,10 @@ const genericRecursive = defineCredential({
       vk.hash,
       credIdent,
     ]);
+  },
+
+  matchesSpec(witness) {
+    return witness.type === 'recursive';
   },
 });
 

--- a/src/credential-signed.ts
+++ b/src/credential-signed.ts
@@ -49,6 +49,10 @@ const Signed = Object.assign(
     issuer({ issuer }) {
       return Poseidon.hashWithPrefix(prefixes.issuerSimple, issuer.toFields());
     },
+
+    matchesSpec(witness) {
+      return witness.type === 'simple';
+    },
   }),
   {
     issuer(issuer: PublicKey) {

--- a/src/credential.ts
+++ b/src/credential.ts
@@ -14,7 +14,7 @@ import {
   type NestedProvableFor,
 } from './nested.ts';
 import { zip } from './util.ts';
-import { hashDynamic } from './dynamic/dynamic-hash.ts';
+import { hashDynamic, provableTypeMatches } from './dynamic/dynamic-hash.ts';
 import { Schema } from './dynamic/schema.ts';
 
 export {
@@ -218,8 +218,7 @@ function credentialMatchesSpec(
   if (!spec.matchesSpec(credential.witness)) return false;
 
   // check that the data type matches
-  // TODO
-  return true;
+  return provableTypeMatches(credential.credential.data, spec.data);
 }
 
 function defineCredential<

--- a/src/dynamic/dynamic-record.ts
+++ b/src/dynamic/dynamic-record.ts
@@ -157,6 +157,9 @@ class GenericRecordBase {
   get maxEntries(): number {
     throw Error('Need subclass');
   }
+  get knownShape() {
+    return {};
+  }
 
   static from(actual: UnknownRecord): GenericRecordBase {
     let entries = Object.entries(actual).map(([key, value]) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,6 +6,7 @@ export {
   assertHasProperty,
   assertHasMethod,
   hasProperty,
+  isObject,
   assertIsObject,
   notImplemented,
   zip,
@@ -62,6 +63,10 @@ function Required<T extends {}>(
       );
     },
   }) as Required<T>;
+}
+
+function isObject(obj: unknown): obj is Record<string, unknown> {
+  return (typeof obj === 'object' && obj !== null) || typeof obj === 'function';
 }
 
 function assertIsObject(


### PR DESCRIPTION
when creating a presentation, check if credentials match the input spec before using them.

this fixes a bug in the current web demo which just passes all available credentials to `Presentation.create()`