### PR TITLE
Export rsaverify circuit and Bigint2048 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ The remainder of this README contains documentation aimed at developers, startin
 - [Code example: Defining a private attestation ](#operations-dsl)
 - [What credentials are supported? ](#credential-kinds)
 - [API](#api)
-- [Bonus: `mina-attestations/dynamic`](#bonus-mina-attestationsdynamic)
+- Bonus: 
+  - [`mina-attestations/dynamic`](#bonus-mina-attestationsdynamic)
+  - [`mina-attestations/rsa`](#bonus-mina-attestationsrsa)
 
 Apart from reading the docs, have a look at our full code examples:
 
@@ -1906,6 +1908,10 @@ let provenHash: Bytes = result.proof.publicOutput;
 
 console.log(provenHash.toHex());
 ```
+
+## Bonus: `mina-attestations/rsa`
+
+The sub-import mina-attestations/rsa provides a library of data types and functions for generating and verifying RSA-65537 signatures. For more details, refer to [this](./src/rsa/README.md).
 
 <!-- ## Further resources and background
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "import": "./build/src/validation-index.js"
     },
     "./rsa":{
-      "import": "./build/src/rsa/rsa.js"
+      "import": "./build/src/rsa-index.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     },
     "./validation": {
       "import": "./build/src/validation-index.js"
+    },
+    "./rsa":{
+      "import": "./build/src/rsa/rsa.js"
     }
   },
   "scripts": {

--- a/src/dynamic.ts
+++ b/src/dynamic.ts
@@ -19,3 +19,4 @@ export { Numeric } from './dynamic/gadgets-numeric.ts';
 
 export { hashDynamic, hashDynamicWithPrefix } from './dynamic/dynamic-hash.ts';
 export { Schema } from './dynamic/schema.ts';
+export { SHA2 } from './dynamic/sha2.ts';

--- a/src/rsa-index.ts
+++ b/src/rsa-index.ts
@@ -1,0 +1,12 @@
+export {
+    power,
+    generateRsaKeys65537,
+    randomPrime,
+    bytesToBigint,
+    bigintToBytes,
+    bytesToBigintBE,
+    bigintToBytesBE,
+} from "./rsa/utils.ts";
+
+export { Bigint2048, rsaVerify65537, rsaSign } from "./rsa/rsa.ts";
+

--- a/src/rsa/README.md
+++ b/src/rsa/README.md
@@ -1,0 +1,78 @@
+# RSA o1js
+
+This folder contains types, provable methods and zkprograms to verify RSA65537 signature in o1js.
+
+"RSA o1js" can be seen as its own, self-contained library which is generally useful, beyond attestations. It can be imported from `mina-attestations/rsa`.
+
+The `rsa.eg.ts` file provides an example of using `rsaVerify65537` in `ZkProgram`, while `rsa.test.ts` includes tests for generating arguments and verifying `rsaVerify65537` outside the circuit.
+## Core Components
+
+### `Bigint2048`
+- A specialized class for handling 2048-bit integers used in RSA cryptography
+- Uses 18 field elements with 116-bit limbs for efficient circuit representation
+- Provides modular arithmetic operations (multiplication and squaring) necessary for RSA
+- Includes conversion methods between native bigints and the circuit-friendly representation
+
+### `rsaVerify65537`
+- Implements RSA signature verification for the common public exponent e=65537
+- Follows the RSASSA-PKCS1-v1.5 signature scheme standard
+- Verifies signatures by computing signature^(2^16+1) mod modulus and comparing to padded message
+
+
+### `rsaSign`
+- Generates RSA signatures according to RSASSA-PKCS1-v1.5 scheme
+- Takes a message hash (expected to be pre-computed) and private key components
+- Not designed to be provable, intended for off-chain signature generation
+
+## Utils
+ Provides cryptographic utilities including key generation, primality testing, and byte conversion functions necessary for RSA operations
+  - `power`: Performs modular exponentiation (a^n mod p) efficiently using the square-and-multiply algorithm
+  - `generateRsaKeys65537`: Creates a random set of 2048-bit RSA keys with the fixed public exponent 65537
+  - `randomPrime`: Generates cryptographically secure random prime numbers of specified bit length using Miller-Rabin primality testing
+  - `bytesToBigint`: Converts a byte array to a bigint using little-endian byte order
+  - `bigintToBytes`: Converts a bigint to a byte array using little-endian byte order
+  - `bytesToBigintBE`: Converts a byte array to a bigint using big-endian byte order
+  - `bigintToBytesBE`: Converts a bigint to a byte array using big-endian byte order
+
+  Example to verify rsa65537 signature using `mina-attestations/rsa`
+  ```
+import { Bytes, ZkProgram } from 'o1js';
+import { SHA2 } from 'mina-attestations/dynamic';
+import { rsaVerify65537, rsaSign, Bigint2048, generateRsaKeys65537 } from 'mina-attestations/rsa';
+
+
+let keys = generateRsaKeys65537();
+
+let message = SHA2.hash(256, 'a test message');
+let signature = rsaSign(message, keys);
+
+const Message = Bytes(32);
+
+let rsaProgram = ZkProgram({
+  name: 'rsa',
+  publicInput: Message,
+
+  methods: {
+    run: {
+      privateInputs: [Bigint2048, Bigint2048],
+
+      async method(message: Bytes, signature: Bigint2048, modulus: Bigint2048) {
+        rsaVerify65537(message, signature, modulus);
+      },
+    },
+  },
+});
+
+console.log((await rsaProgram.analyzeMethods()).run.summary());
+
+await rsaProgram.compile();
+
+// Run the program
+await rsaProgram.run(
+  message,
+  Bigint2048.from(signature),
+  Bigint2048.from(keys.n)
+);
+
+
+  ```

--- a/src/rsa/README.md
+++ b/src/rsa/README.md
@@ -35,7 +35,7 @@ The `rsa.eg.ts` file provides an example of using `rsaVerify65537` in `ZkProgram
   - `bigintToBytesBE`: Converts a bigint to a byte array using big-endian byte order
 
   Example to verify rsa65537 signature using `mina-attestations/rsa`
-  ```
+  ```ts
 import { Bytes, ZkProgram } from 'o1js';
 import { SHA2 } from 'mina-attestations/dynamic';
 import { rsaVerify65537, rsaSign, Bigint2048, generateRsaKeys65537 } from 'mina-attestations/rsa';


### PR DESCRIPTION
This PR resolves the issue where rsaverifyCircuit and Bigint2048 couldn't be imported from the mina-attestations package and eliminates the need for manual code copying.

```
import { Bigint2048, rsaVerify65537, rsaSign } from 'mina-attestations/rsa`
```